### PR TITLE
Disable taskbar_on_phones to allow NavBar Pulse

### DIFF
--- a/aconfig/bp1a/com.android.systemui/communal_hub_flag_values.textproto
+++ b/aconfig/bp1a/com.android.systemui/communal_hub_flag_values.textproto
@@ -1,6 +1,6 @@
 flag_value {
   package: "com.android.systemui"
   name: "communal_hub"
-  state: DISABLED
+  state: ENABLED
   permission: READ_ONLY
 }

--- a/aconfig/bp1a/com.android.systemui/migrate_clocks_to_blueprint_flag_values.textproto
+++ b/aconfig/bp1a/com.android.systemui/migrate_clocks_to_blueprint_flag_values.textproto
@@ -1,6 +1,6 @@
 flag_value {
   package: "com.android.systemui"
   name: "migrate_clocks_to_blueprint"
-  state: DISABLED
+  state: ENABLED
   permission: READ_ONLY
 }

--- a/aconfig/bp1a/com.android.wm.shell/enable_taskbar_on_phones_flag_values.textproto
+++ b/aconfig/bp1a/com.android.wm.shell/enable_taskbar_on_phones_flag_values.textproto
@@ -1,6 +1,6 @@
 flag_value {
   package: "com.android.wm.shell"
   name: "enable_taskbar_on_phones"
-  state: ENABLED
+  state: DISABLED
   permission: READ_ONLY
 }

--- a/flag_values/bp1a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
+++ b/flag_values/bp1a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
@@ -1,4 +1,4 @@
 name: "RELEASE_PLATFORM_SECURITY_PATCH"
 value: {
-  string_value: "2025-05-05"
+  string_value: "2025-06-05"
 }


### PR DESCRIPTION
This will set supportsTaskBar to false:
https://github.com/LineageOS/android_frameworks_base/blob/51f865cceadb28984608aece3e6760c7e881512f/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBarControllerImpl.java#L266C13-L266C28

Which will allow `getNavigationBar()` to not return Null

https://github.com/LineageOS/android_frameworks_base/blob/51f865cceadb28984608aece3e6760c7e881512f/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBarControllerImpl.java#L463

After this the NavBar Pulse configs can be added back